### PR TITLE
Fix typo in COVERAGE_EXCLUDE in docsting and help message

### DIFF
--- a/roswell/run-fiveam.ros
+++ b/roswell/run-fiveam.ros
@@ -23,7 +23,7 @@ allowing package qualified test names to be used.
 
 If the COVERALLS environemenal variable is present and non-empty, coverage will
 be measured and reported to COVERALLS on platforms supported by CI-Utils.
-Additionally, the environmental variable COVERAGE_EXCLUDED is read as a colon
+Additionally, the environmental variable COVERAGE_EXCLUDE is read as a colon
 seperated list of paths to exclude from measuring coverage, in addition to those
 specified as arguments.
 

--- a/src/coveralls.lisp
+++ b/src/coveralls.lisp
@@ -22,7 +22,7 @@
                  ,@body))
 
 (defun coverage-excluded ()
-  "Gets the contents of the COVERAGE_EXCLUDED environemental variable as a list
+  "Gets the contents of the COVERAGE_EXCLUDE environemental variable as a list
    of path strings"
   ; Copied from Eitaro Fukamachi's run-prove under the MIT license
   ; https://github.com/fukamachi/prove/blob/master/roswell/run-prove.ros


### PR DESCRIPTION
Hi! I noticed a mismatch in run-fiveam help message with actual COVERAGE_EXCLUDE variable name.